### PR TITLE
File fields expandable to handle long filenames

### DIFF
--- a/src/app/project/project-documents/document-edit/document-edit.component.html
+++ b/src/app/project/project-documents/document-edit/document-edit.component.html
@@ -76,14 +76,14 @@
       <div *ngIf="documents && documents.length === 1" class="form-row">
         <div class="form-group col-md-12">
           <label for="displayName">Document Name</label>
-          <input type="text" class="form-control" id="displayName" name="displayName" formControlName="displayName">
+          <textarea class="form-control" id="displayName" name="displayName" rows="1" formControlName="displayName"></textarea>
         </div>
       </div>
       <div class="form-row">
         <div class="form-group col-md-12">
           <label for="inputDescription">Description</label>
-          <input type="text" class="form-control" id="inputDescription" name="description"
-            formControlName="description">
+          <textarea class="form-control" id="inputDescription" name="description" rows="1"
+            formControlName="description"></textarea>
         </div>
       </div>
     </form>

--- a/src/app/project/project-documents/upload/upload.component.html
+++ b/src/app/project/project-documents/upload/upload.component.html
@@ -67,15 +67,15 @@
         <div class="form-group col-md-12">
           <label for="displayName">Document Name</label>
           <div>
-              <input *ngIf="documents && documents.length > 1" disabled type="text" class="form-control" id="displayName" name="displayName" formControlName="displayName">
-              <input *ngIf="!documents || documents.length < 2" type="text" class="form-control" id="displayName" name="displayName" formControlName="displayName">
+              <textarea *ngIf="documents && documents.length > 1" disabled class="form-control" id="displayName" name="displayName" rows="1" formControlName="displayName"></textarea>
+              <textarea *ngIf="!documents || documents.length < 2" class="form-control" id="displayName" name="displayName" rows="1" formControlName="displayName"></textarea>
           </div>
         </div>
       </div>
       <div class="form-row">
         <div class="form-group col-md-12">
           <label for="inputDescription">Description</label>
-          <textarea class="form-control" id="inputDescription" name="description"
+          <textarea class="form-control" id="inputDescription" name="description" rows="1"
             formControlName="description"></textarea>
         </div>
       </div>


### PR DESCRIPTION
This is a UI change requested in order to be able to deal with existing lengthy file names.  The issue is that in a text input field, one can either snap to the start or end, but not easily navigate in the middle.  With a textarea, one can expand it down and view the whole string at once.