### PR TITLE
EE-275 fixed pagination on group contact page

### DIFF
--- a/src/app/project/project-groups/group-contact/group-contact.component.ts
+++ b/src/app/project/project-groups/group-contact/group-contact.component.ts
@@ -395,23 +395,10 @@ export class GroupContactComponent implements OnInit, OnDestroy {
     this.loading = true;
 
     this.tableParams = this.tableTemplateUtils.updateTableParams(this.tableParams, pageNumber, this.tableParams.sortBy);
-
-    this.searchService.getSearchResults(null,
-      'User',
-      null,
-      pageNumber,
-      this.tableParams.pageSize,
-      this.tableParams.sortBy,
-      {})
-      .takeUntil(this.ngUnsubscribe)
-      .subscribe((res: any) => {
-        this.tableParams.totalListItems = res[0].data.meta[0].searchResultsTotal;
-        this.users = res[0].data.searchResults;
-        this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, null, null || '');
-        this.setRowData();
-        this.loading = false;
-        this._changeDetectionRef.detectChanges();
-      });
+    this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, null, null || '');
+    this.setRowData();
+    this.loading = false;
+    this._changeDetectionRef.detectChanges();
   }
 
   async saveName() {


### PR DESCRIPTION
There is a pagination issue in the prod version of this page, clicking the `2` link or the `next` button loads _all_ contacts from the db, and adds a bunch more pages to the navigation. Deleting this search seemed to fix it, i think updating `this.tableParams` is all that needs to be done to display the next page of results.