### PR TITLE
Hide autofill on net new projects

### DIFF
--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -73,12 +73,31 @@ export class AddEditProjectComponent implements OnInit, OnDestroy {
 
     this.initProject();
 
-    // hide tabs corresponding to old legislations on new projects
+    // hide tabs corresponding to old legislations on new project creation
     if (!this.pageIsEditing) {
       this.tabLinks = [this.tabLinks[this.tabLinks.length - 1]];
     }
+
+    const emptyOldYears = this.getEmptyOldYears();
+    // hide tabs corresponding to old legislations on new project edit
+    this.tabLinks = this.tabLinks.filter((tab: IAddEditTab) => {
+      // keep tab if at least one if its years is not in emptyOldYears
+      return tab.years.reduce((res: Boolean, year: string) => Boolean(res || !emptyOldYears.includes(year)), false);
+    });
     this.loading = false;
     this.back = this.storageService.state.back;
+  }
+
+  // get list of years corresponding to older legislations that are empty
+  getEmptyOldYears() {
+    // get list all possible years from this.tabLinks
+    const years = this.tabLinks.reduce((arr: string[], value: IAddEditTab) => arr.concat(value.years), []);
+    // return list of years that are both old and have no data
+    return years.filter((year: string) => {
+      const yearIsOld = year < this.fullProject.currentLegislationYear;
+      const yearHasData = this.fullProject.legislationYearList.includes(parseInt(year.split('_')[1], 10));
+      return yearIsOld && !yearHasData;
+    });
   }
 
   initProject() {

--- a/src/app/projects/add-edit-project/add-edit-project.component.ts
+++ b/src/app/projects/add-edit-project/add-edit-project.component.ts
@@ -77,13 +77,6 @@ export class AddEditProjectComponent implements OnInit, OnDestroy {
     if (!this.pageIsEditing) {
       this.tabLinks = [this.tabLinks[this.tabLinks.length - 1]];
     }
-
-    const emptyOldYears = this.getEmptyOldYears();
-    // hide tabs corresponding to old legislations on new project edit
-    this.tabLinks = this.tabLinks.filter((tab: IAddEditTab) => {
-      // keep tab if at least one if its years is not in emptyOldYears
-      return tab.years.reduce((res: Boolean, year: string) => Boolean(res || !emptyOldYears.includes(year)), false);
-    });
     this.loading = false;
     this.back = this.storageService.state.back;
   }
@@ -97,6 +90,15 @@ export class AddEditProjectComponent implements OnInit, OnDestroy {
       const yearIsOld = year < this.fullProject.currentLegislationYear;
       const yearHasData = this.fullProject.legislationYearList.includes(parseInt(year.split('_')[1], 10));
       return yearIsOld && !yearHasData;
+    });
+  }
+
+  initTabs() {
+    const emptyOldYears = this.getEmptyOldYears();
+    // hide tabs corresponding to old legislations on new project edit
+    this.tabLinks = this.tabLinks.filter((tab: IAddEditTab) => {
+      // keep tab if at least one if its years is not in emptyOldYears
+      return tab.years.reduce((res: Boolean, year: string) => Boolean(res || !emptyOldYears.includes(year)), false);
     });
   }
 
@@ -115,9 +117,10 @@ export class AddEditProjectComponent implements OnInit, OnDestroy {
             // we don't have ids on project here, have to use id from fullProject
             this.storageService.state.projectDetailId = this.fullProject._id;
             this.storageService.state.projectDetailName = this.project.name;
+
+            this.initTabs();
           }
         }
-
         this.loading = false;
       });
   }

--- a/src/app/projects/add-edit-project/form-tab-2018/form-tab-2018.component.html
+++ b/src/app/projects/add-edit-project/form-tab-2018/form-tab-2018.component.html
@@ -3,7 +3,7 @@
     <section>
       <h2>Basic Information
         &nbsp;
-        <button *ngIf="pageIsEditing" class="btn btn-primary btn-autofill" type="publish" (click)="autofill()">Autofill</button>
+        <button *ngIf="pageIsEditing && (fullProject.legislationYearList.length > 1)" class="btn btn-primary btn-autofill" type="publish" (click)="autofill()">Autofill</button>
       </h2>
 
       <div class="flex-container">


### PR DESCRIPTION
autofill button shouldn't show up if it is a net new project with no old data to copy in.