### PR TITLE
Editable project phase

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:4200",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.html
+++ b/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.html
@@ -48,6 +48,13 @@
 
           </select>
         </div>
+        <div class="label-pair">
+          <label for="currentPhaseName">Project Phase* </label>
+          <select name="currentPhaseName" id="currentPhaseName" formControlName="currentPhaseName" class="form-control">
+            <option *ngFor="let projectPhase of projectPhases" [ngValue]="currentPhaseName">{{projectPhase.name}}</option>
+
+          </select>
+        </div>
         <div class="label-pair med">
           <label for="description">Description* </label>
           <textarea name="description" id="description" formControlName="description" class="form-control"></textarea>

--- a/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.html
+++ b/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.html
@@ -51,7 +51,7 @@
         <div class="label-pair">
           <label for="currentPhaseName">Project Phase* </label>
           <select name="currentPhaseName" id="currentPhaseName" formControlName="currentPhaseName" class="form-control">
-            <option *ngFor="let projectPhase of projectPhases" [ngValue]="currentPhaseName">{{projectPhase.name}}</option>
+            <option *ngFor="let projectPhase of projectPhases" [ngValue]="projectPhase._id">{{projectPhase.name}}</option>
 
           </select>
         </div>

--- a/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.ts
+++ b/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.ts
@@ -792,6 +792,7 @@ export class FormTab2002Component implements OnInit, OnDestroy {
     // Sorts by legislation first and then listOrder for each legislation group.
     this.eacDecisions = _.sortBy(this.eacDecisions, ['legislation', 'listOrder']);
     this.ceaaInvolvements = _.sortBy(this.ceaaInvolvements, ['legislation', 'listOrder']);
+    this.projectPhases = _.sortBy(this.projectPhases, ['legislation', 'listOrder']);
   }
 
   ngOnDestroy() {

--- a/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.ts
+++ b/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.ts
@@ -39,6 +39,7 @@ export class FormTab2002Component implements OnInit, OnDestroy {
   public back: any = {};
   public regions: any[] = [];
   public sectorsSelected = [];
+  public projectPhases: Array<any> = [];
   public proponentName = '';
   public proponentId = '';
   public legislationYear: Number = 2002;
@@ -125,6 +126,8 @@ export class FormTab2002Component implements OnInit, OnDestroy {
         this.buildForm();
         this.initContacts();
         this.getLists();
+
+
 
         this.loading = false;
         try {
@@ -217,6 +220,7 @@ export class FormTab2002Component implements OnInit, OnDestroy {
       this.myForm = new FormGroup({
         'name': new FormControl(),
         'proponent': new FormControl(),
+        'currentPhaseName': new FormControl(this.projectPhases[0]),
         'build': new FormControl(),
         'type': new FormControl(),
         'sector': new FormControl(),
@@ -377,6 +381,7 @@ export class FormTab2002Component implements OnInit, OnDestroy {
       'proponent': new FormControl(formData.proponent),
       'build': new FormControl(formData.build),
       'type': new FormControl(formData.type),
+      'currentPhaseName': new FormControl(formData.currentPhaseName),
       'sector': new FormControl(formData.sector),
       'description': new FormControl(formData.description),
       'location': new FormControl(formData.location),
@@ -444,6 +449,7 @@ export class FormTab2002Component implements OnInit, OnDestroy {
       'proponent': this.proponentId,
       'build': form.controls.build.value,
       'type': form.controls.type.value,
+      'currentPhaseName': form.controls.currentPhaseName.value,
       'sector': form.controls.sector.value,
       'description': form.controls.description.value,
       'location': form.controls.location.value,
@@ -505,6 +511,9 @@ export class FormTab2002Component implements OnInit, OnDestroy {
       return false;
     } else if (this.myForm.controls.type.value === '') {
       alert('You must select a type.');
+      return false;
+    } else if (this.myForm.controls.currentPhaseName.value === '') {
+      alert('You must select a project phase.');
       return false;
     } else if (this.myForm.controls.sector.value === '') {
       alert('You must select a sub-type.');
@@ -770,6 +779,9 @@ export class FormTab2002Component implements OnInit, OnDestroy {
             break;
           case `ceaaInvolvements|${this.legislationYear}`:
             this.ceaaInvolvements.push({ ...item });
+            break;
+          case `projectPhase|${this.legislationYear}`:
+            this.projectPhases.push({ ...item});
             break;
           default:
             break;

--- a/src/app/projects/add-edit-project/form-tab-2018/form-tab-2018.component.html
+++ b/src/app/projects/add-edit-project/form-tab-2018/form-tab-2018.component.html
@@ -51,6 +51,13 @@
 
           </select>
         </div>
+        <div class="label-pair">
+          <label for="currentPhaseName">Project Phase* </label>
+          <select name="currentPhaseName" id="currentPhaseName" formControlName="currentPhaseName" class="form-control">
+            <option *ngFor="let projectPhase of projectPhases" [ngValue]="projectPhase._id">{{projectPhase.name}}</option>
+
+          </select>
+        </div>
         <div class="label-pair med">
           <label for="description">Description* </label>
           <textarea name="description" id="description" formControlName="description" class="form-control"></textarea>

--- a/src/app/projects/add-edit-project/form-tab-2018/form-tab-2018.component.ts
+++ b/src/app/projects/add-edit-project/form-tab-2018/form-tab-2018.component.ts
@@ -32,6 +32,7 @@ export class FormTab2018Component implements OnInit, OnDestroy {
   public back: any = {};
   public regions: any[] = [];
   public sectorsSelected = [];
+  public projectPhases: Array<any> = [];
   public proponentName = '';
   public proponentId = '';
   public ceaaInvolvements: Array<any> = [];
@@ -191,6 +192,7 @@ export class FormTab2018Component implements OnInit, OnDestroy {
       this.myForm = new FormGroup({
         'name': new FormControl(),
         'proponent': new FormControl(),
+        'currentPhaseName': new FormControl(this.projectPhases[0]),
         'build': new FormControl(),
         'type': new FormControl(),
         'sector': new FormControl(),
@@ -338,6 +340,7 @@ export class FormTab2018Component implements OnInit, OnDestroy {
       'proponent': new FormControl(formData.proponent),
       'build': new FormControl(formData.build),
       'type': new FormControl(formData.type),
+      'currentPhaseName': new FormControl(formData.currentPhaseName._id),
       'sector': new FormControl(formData.sector),
       'description': new FormControl(formData.description),
       'location': new FormControl(formData.location),
@@ -408,6 +411,7 @@ export class FormTab2018Component implements OnInit, OnDestroy {
       'proponent': this.proponentId,
       'build': form.controls.build.value,
       'type': form.controls.type.value,
+      'currentPhaseName': form.controls.currentPhaseName.value,
       'sector': form.controls.sector.value,
       'description': form.controls.description.value,
       'location': form.controls.location.value,
@@ -469,6 +473,9 @@ export class FormTab2018Component implements OnInit, OnDestroy {
       return false;
     } else if (this.myForm.controls.sector.value === '') {
       alert('You must select a sub-type.');
+      return false;
+    } else if (this.myForm.controls.currentPhaseName.value === '') {
+      alert('You must select a project phase.');
       return false;
     } else if (this.myForm.controls.description.value === '') {
       alert('Description cannot be empty.');
@@ -750,6 +757,9 @@ export class FormTab2018Component implements OnInit, OnDestroy {
           case `ceaaInvolvements|${this.legislationYear}`:
             this.ceaaInvolvements.push({ ...item });
             break;
+          case `projectPhase|${this.legislationYear}`:
+            this.projectPhases.push({ ...item});
+            break;
           default:
             break;
         }
@@ -759,6 +769,7 @@ export class FormTab2018Component implements OnInit, OnDestroy {
     // Sorts by legislation first and then listOrder for each legislation group.
     this.eacDecisions = _.sortBy(this.eacDecisions, ['legislation', 'listOrder']);
     this.ceaaInvolvements = _.sortBy(this.ceaaInvolvements, ['legislation', 'listOrder']);
+    this.projectPhases = _.sortBy(this.projectPhases, ['legislation', 'listOrder']);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
EE-695 Make Project Phase on Projects an editable field

Added the project phase to the edit menu as a dropdown. Dropdown should select the current phase unless it is from a different legislation year. Saving should update the current phase. The 2002 and 2018 changes are similar but not identical. (The 2018 form control has to select _id).

Related API change:
https://github.com/bcgov/eagle-api/pull/395