### PR TITLE
Tracking doc hits

### DIFF
--- a/src/app/models/document.ts
+++ b/src/app/models/document.ts
@@ -30,6 +30,9 @@ export class Document {
   isPublished = false; // depends on tags; see below
 
   isFeatured = false;
+  secureHitCount = 0;
+  publicHitCount = 0;
+  sortOrder = 0;
 
   read: Array<String> = [];
 
@@ -66,5 +69,8 @@ export class Document {
     this.read = obj && obj.read || null;
 
     this.isFeatured = obj && obj.isFeatured || null;
+    this.sortOrder = obj && obj.sortOrder || null;
+    this.publicHitCount = obj && obj.publicHitCount || null;
+    this.secureHitCount = obj && obj.secureHitCount || null;
   }
 }

--- a/src/app/project/project-documents/detail/detail.component.html
+++ b/src/app/project/project-documents/detail/detail.component.html
@@ -32,11 +32,11 @@
       <p id="displayName">{{document.displayName || '-'}}</p>
     </div>
     <div class="label-pair">
-      <h3 for="publicHitCount">Public Hits: </h3>
+      <h3 for="publicHitCount">Public Views: </h3>
       <p id="publicHitCount">{{document.publicHitCount || '-'}}</p>
     </div>
     <div class="label-pair">
-      <h3 for="secureHitCount">Secure Hits: </h3>
+      <h3 for="secureHitCount">Secure Views: </h3>
       <p id="secureHitCount">{{document.secureHitCount || '-'}}</p>
     </div>
     <div class="label-pair">

--- a/src/app/project/project-documents/detail/detail.component.html
+++ b/src/app/project/project-documents/detail/detail.component.html
@@ -32,6 +32,14 @@
       <p id="displayName">{{document.displayName || '-'}}</p>
     </div>
     <div class="label-pair">
+      <h3 for="publicHitCount">Public Hits: </h3>
+      <p id="publicHitCount">{{document.publicHitCount || '-'}}</p>
+    </div>
+    <div class="label-pair">
+      <h3 for="secureHitCount">Secure Hits: </h3>
+      <p id="secureHitCount">{{document.secureHitCount || '-'}}</p>
+    </div>
+    <div class="label-pair">
       <p id="status publish-state">
         <i class="material-icons">
           {{publishText === 'Publish' ?   'cloud_off' : 'cloud_done' || '-'}}

--- a/src/app/project/project-documents/project-documents.component.ts
+++ b/src/app/project/project-documents/project-documents.component.ts
@@ -97,7 +97,7 @@ export class ProjectDocumentsComponent implements OnInit, OnDestroy {
     {
       name: 'Name',
       value: 'displayName',
-      width: 'col-6'
+      width: 'col-4'
     },
     {
       name: 'Status',
@@ -107,7 +107,7 @@ export class ProjectDocumentsComponent implements OnInit, OnDestroy {
     {
       name: 'Date',
       value: 'datePosted',
-      width: 'col-2'
+      width: 'col-1'
     },
     {
       name: 'Type',
@@ -117,7 +117,7 @@ export class ProjectDocumentsComponent implements OnInit, OnDestroy {
     {
       name: 'Milestone',
       value: 'milestone',
-      width: 'col-2'
+      width: 'col-1'
     },
     {
       name: 'Legislation',
@@ -127,7 +127,7 @@ export class ProjectDocumentsComponent implements OnInit, OnDestroy {
     {
       name: 'Feature',
       value: 'isFeatured',
-      width: 'col-2'
+      width: 'col-1'
     }
   ];
 
@@ -659,7 +659,10 @@ export class ProjectDocumentsComponent implements OnInit, OnDestroy {
           _id: document._id,
           project: document.project,
           read: document.read,
-          isFeatured: document.isFeatured
+          isFeatured: document.isFeatured,
+          sortOrder: document.sortOrder,
+          publicHitCount: document.publicHitCount,
+          secureHitCount: document.secureHitCount
         });
       });
 

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -700,7 +700,10 @@ export class ApiService {
       'displayName',
       'internalURL',
       'internalMime',
-      'isFeatured'
+      'isFeatured',
+      'sortOrder',
+      'secureHitCount',
+      'publicHitCount'
     ];
     const queryString = `document?isDeleted=false&_project=${projId}&fields=${this.buildValues(fields)}`;
     return this.http.get<Document[]>(`${this.pathAPI}/${queryString}`, {});
@@ -732,7 +735,10 @@ export class ApiService {
       'milestone',
       'description',
       'isPublished',
-      'isFeatured'
+      'isFeatured',
+      'sortOrder',
+      'secureHitCount',
+      'publicHitCount'
     ];
     const queryString = `document?docIds=${this.buildValues(ids)}&fields=${this.buildValues(fields)}`;
     return this.http.get<Document[]>(`${this.pathAPI}/${queryString}`, {});
@@ -764,7 +770,10 @@ export class ApiService {
       'milestone',
       'description',
       'isPublished',
-      'isFeatured'
+      'isFeatured',
+      'sortOrder',
+      'secureHitCount',
+      'publicHitCount'
     ];
     const queryString = `document/${id}?fields=${this.buildValues(fields)}`;
     return this.http.get<Document[]>(`${this.pathAPI}/${queryString}`, {});


### PR DESCRIPTION
Adding support to view the document hit counts on the Document Details screen

See ticket [EE-842](https://bcmines.atlassian.net/browse/EE-842)

Note: Has a dependency on the [API PR 409](https://github.com/bcgov/eagle-api/pull/409)