### PR TITLE
FIxing inconsistent paging values for organizations

### DIFF
--- a/src/app/project/pins-list/pins-global-resolver.service.ts
+++ b/src/app/project/pins-list/pins-global-resolver.service.ts
@@ -13,7 +13,7 @@ export class PinsGlobalComponentResolver implements Resolve<Observable<object>> 
 
   resolve(route: ActivatedRouteSnapshot): Observable<object> {
     const pageNum = route.params.currentPage ? route.params.currentPage : 1;
-    const pageSize = route.params.pageSize ? route.params.pageSize : 25;
+    const pageSize = route.params.pageSize ? route.params.pageSize : 10;
     const sortBy = route.params.sortBy ? route.params.sortBy : '+name';
     const keywords = route.params.keywords || '';
 

--- a/src/app/project/pins-list/pins-list.component.ts
+++ b/src/app/project/pins-list/pins-list.component.ts
@@ -239,7 +239,7 @@ export class PinsListComponent implements OnInit, OnDestroy {
         }
       ]
     );
-    this.router.navigate(['/p', this.currentProject._id, 'project-pins', 'select', { pageSize: 25 }]);
+    this.router.navigate(['/p', this.currentProject._id, 'project-pins', 'select', { pageSize: 10 }]);
   }
 
   public onSubmit(pageNumber = 1, reset = false) {

--- a/src/app/shared/components/link-organization/link-organization-resolver.services.ts
+++ b/src/app/shared/components/link-organization/link-organization-resolver.services.ts
@@ -13,7 +13,7 @@ export class LinkOrganizationResolver implements Resolve<Observable<object>> {
   ) { }
 
   resolve(route: ActivatedRouteSnapshot): Observable<object> {
-    let tableParams = this.tableTemplateUtils.getParamsFromUrl(route.params, null, 15);
+    let tableParams = this.tableTemplateUtils.getParamsFromUrl(route.params, null, 10);
     if (tableParams.sortBy === '') {
       tableParams.sortBy = '+name';
       this.tableTemplateUtils.updateUrl(tableParams.sortBy, tableParams.currentPage, tableParams.pageSize, null, tableParams.keywords);

--- a/src/app/shared/components/link-organization/link-organization.component.ts
+++ b/src/app/shared/components/link-organization/link-organization.component.ts
@@ -76,7 +76,7 @@ export class LinkOrganizationComponent implements OnInit, OnDestroy {
           this.contactId = params.contactId;
           this.isEditing = true;
         }
-        this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, null, 15);
+        this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, null, 10);
         if (this.tableParams.sortBy === '') {
           this.tableParams.sortBy = '+name';
           this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, null, this.tableParams.keywords);


### PR DESCRIPTION
The Participating Indigenous Nations tabs were using inconsistent values and overriding default values for page sizes. These have been changed to match the default values of 10.

In the future, these values should be identified throughout the applications (public too!) and put into constants.

See ticket [EE-597](https://bcmines.atlassian.net/browse/EE-597)