### PR TITLE
Fix for 96 leg projects to show list codes

### DIFF
--- a/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.ts
+++ b/src/app/projects/add-edit-project/form-tab-2002/form-tab-2002.component.ts
@@ -773,14 +773,18 @@ export class FormTab2002Component implements OnInit, OnDestroy {
   getLists() {
     this.config.getLists().subscribe (lists => {
       lists.map(item => {
+        // List values only have 2002 and 2018 values.
+        // If a project is set to 1996 legislation, make sure
+        // to load the 2002 codes.
+        let tempLegislationYear = this.legislationYear === 1996 ? 2002 : this.legislationYear;
         switch (`${item.type}|${item.legislation}`) {
-          case `eaDecisions|${this.legislationYear}`:
+          case `eaDecisions|${tempLegislationYear}`:
             this.eacDecisions.push({ ...item });
             break;
-          case `ceaaInvolvements|${this.legislationYear}`:
+          case `ceaaInvolvements|${tempLegislationYear}`:
             this.ceaaInvolvements.push({ ...item });
             break;
-          case `projectPhase|${this.legislationYear}`:
+          case `projectPhase|${tempLegislationYear}`:
             this.projectPhases.push({ ...item});
             break;
           default:


### PR DESCRIPTION
List codes were hard-mapped to 2002 and 2018, so 1996 projects would not show any list values. This fix just creates a temp value to grab 2002 codes if the project is a 1996 legislation.

See ticket [EE-905](https://bcmines.atlassian.net/browse/EE-905)