### PR TITLE
NOBUG: Fix karma config and test runner

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,8 @@
 // https://karma-runner.github.io/0.13/config/configuration-file.html
 
 //Set the chrome_bin env here for the pod
-process.env.CHROME_BIN = require('puppeteer').executablePath()
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -38,13 +39,35 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadlessNoSandbox'],
+    browsers: ['ChromeHeadless'],
     customLaunchers: {
         ChromeHeadlessNoSandbox: {
             base: 'ChromeHeadless',
             flags: [
-              '--no-sandbox',
-              '--v=1',
+              '--no-sandbox', // required to run without privileges in docker
+              '--user-data-dir=/tmp/chrome-test-profile',
+              '--disable-web-security',
+              '--disable-gpu',
+              '--disable-background-networking',
+              '--disable-default-apps',
+              '--disable-extensions',
+              '--disable-sync',
+              '--disable-translate',
+              '--headless',
+              '--hide-scrollbars',
+              '--metrics-recording-only',
+              '--mute-audio',
+              '--no-first-run',
+              '--safebrowsing-disable-auto-update',
+              '--ignore-certificate-errors',
+              '--ignore-ssl-errors',
+              '--ignore-certificate-errors-spki-list',
+              '--remote-debugging-port=9222',
+              '--remote-debugging-address=0.0.0.0',
+              '--disable-dev-shm-usage',
+              '--disable-setuid-sandbox',
+              '--disable-namespace-sandbox',
+              '--window-size=800x600',
               '--disable-background-timer-throttling',
               '--disable-renderer-backgrounding'
             ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "ng build --prod --deploy-url /admin/ --base-href /admin/",
     "pretest": "",
     "test": "echo 'Test suite should be run with \"`npm run tests` or npm `run tests-ci`\"'",
-    "tests": "ng test",
+    "tests": "ng test --watch=false",
     "tests-ci": "ng test --watch=false",
     "lint": "ng lint --format=stylish",
     "e2e": "ng e2e"


### PR DESCRIPTION
This makes some optimizations to karma/chrome headless, and the npm run tests command.  Now this will drop to a shell after running `npm run tests`, since watching it wont.