### PR TITLE
Local keycloak auth workaround

### DIFF
--- a/src/app/services/auth-guard.service.ts
+++ b/src/app/services/auth-guard.service.ts
@@ -2,16 +2,23 @@ import { Injectable } from '@angular/core';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router, Route } from '@angular/router';
 import { Observable } from 'rxjs';
 import { KeycloakService } from 'app/services/keycloak.service';
+import { ApiService } from 'app/services/api';
 
 
 @Injectable()
 export class AuthGuard implements CanActivate {
+  private _api: ApiService;
 
   constructor( private router: Router,
-    private keycloakService: KeycloakService, ) {
+    private keycloakService: KeycloakService,
+    private api: ApiService, ) {
+      this._api = api;
   }
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+    if (this.api.env === 'local'){
+      return true;
+    }
     if (this.keycloakService.isValidForSite()) {
       return true;
     }

--- a/src/app/services/auth-guard.service.ts
+++ b/src/app/services/auth-guard.service.ts
@@ -16,10 +16,10 @@ export class AuthGuard implements CanActivate {
   }
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
-    if (this.api.env === 'local'){
+    if ( this.api.env === 'local') {
       return true;
     }
-    if (this.keycloakService.isValidForSite()) {
+    if ( this.keycloakService.isValidForSite()) {
       return true;
     }
     this.router.navigate(['/not-authorized']);


### PR DESCRIPTION
Currently on local Admin keylocal loses it's token in chrome after being logged in. This does not happen in Firefox and Edge. Since this issue does not present in Dev, Test or Prod this is a workaround which skips the guard in the case of local development.

Ticket: https://bcmines.atlassian.net/browse/EE-945