### PR TITLE
Route fix, default PN sort order by create date

### DIFF
--- a/src/app/project-notification/documents/upload/upload.component.ts
+++ b/src/app/project-notification/documents/upload/upload.component.ts
@@ -101,13 +101,14 @@ export class UploadComponent implements OnInit, OnDestroy {
         },
         error => {
           console.log('error =', error);
-          alert('Uh-oh, couldn\'t delete project');
-          // TODO: should fully reload project here so we have latest non-deleted objects
+          alert('Document upload failed due to a service error.');
+          this.router.navigate(['pn', this.currentProject._id, 'project-notification-documents']);
+          this.loading = false;
         },
         () => { // onCompleted
           // delete succeeded --> navigate back to search
           // Clear out the document state that was stored previously.
-          this.router.navigate(['p', this.currentProject._id, 'project-documents']);
+          this.router.navigate(['pn', this.currentProject._id, 'project-notification-documents']);
           this.loading = false;
         }
       );

--- a/src/app/project-notifications/project-notifications.component.ts
+++ b/src/app/project-notifications/project-notifications.component.ts
@@ -63,6 +63,10 @@ export class ProjectNotificationsComponent implements OnInit, OnDestroy {
       .takeUntil(this.ngUnsubscribe)
       .subscribe(params => {
         this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params);
+        // default sort order
+        if (this.tableParams.sortBy === '') {
+          this.tableParams.sortBy = '-_id';
+        }
         this.route.data
           .takeUntil(this.ngUnsubscribe)
           .subscribe((res: any) => {


### PR DESCRIPTION
Small fix to fix an ugly error message, fix a re-route in admin project notification documents page. Set default sort to create date (using -_id, we can convert that to a date if needed)

See tickets [EE-875](https://bcmines.atlassian.net/browse/EE-875) and [EE-952](https://bcmines.atlassian.net/browse/EE-942)