### PR TITLE
Project group member paging

### DIFF
--- a/src/app/project/project-groups/group-contact/group-contact.component.html
+++ b/src/app/project/project-groups/group-contact/group-contact.component.html
@@ -50,7 +50,7 @@
                       aria-label="Toolbar with button groups">
                       <div class="btn-group-toggle mr-2" role="group" aria-label="First group">
                           <a href="javascript:void(0);" role="button" class="btn btn-primary"
-                              (click)="tableParams.pageSize=this.tableParams.totalListItems; onSubmit();"
+                              (click)="tableParams.pageSize=this.tableParams.totalListItems; getPaginatedContacts(1);"
                               aria-pressed="tableParams.pageSize === this.tableParams.totalListItems"
                               [ngClass]="{'active': this.tableParams.pageSize === this.tableParams.totalListItems}">Show
                               All Group Members</a>

--- a/src/app/project/project-groups/group-contact/group-contact.component.ts
+++ b/src/app/project/project-groups/group-contact/group-contact.component.ts
@@ -91,8 +91,9 @@ export class GroupContactComponent implements OnInit, OnDestroy {
       .subscribe((res: any) => {
         // Incoming users
         if (res && res.users && res.users.length > 0) {
-          this.tableParams.totalListItems = res.users.length;
-          this.users = res.users;
+          this.tableParams.totalListItems = res.users[0].total_items;
+          this.tableParams.pageSize = 10; // force to default on init
+          this.users = res.users[0].results;
         } else {
           this.tableParams.totalListItems = 0;
           this.users = [];
@@ -404,8 +405,8 @@ export class GroupContactComponent implements OnInit, OnDestroy {
     .takeUntil(this.ngUnsubscribe)
     .subscribe((res: any) => {
       // Incoming users
-      this.tableParams.totalListItems = res.length;
-      this.users = res;
+      this.tableParams.totalListItems = res[0].total_items;
+      this.users = res[0].results;
 
       this.setRowData();
       this.loading = false;

--- a/src/app/project/project-groups/group-contact/group-contact.component.ts
+++ b/src/app/project/project-groups/group-contact/group-contact.component.ts
@@ -90,7 +90,7 @@ export class GroupContactComponent implements OnInit, OnDestroy {
       .takeUntil(this.ngUnsubscribe)
       .subscribe((res: any) => {
         // Incoming users
-        if (res && res.users && res.users.length > 0) {
+        if (res && res.users[0] && res.users[0].total_items > 0) {
           this.tableParams.totalListItems = res.users[0].total_items;
           this.tableParams.pageSize = 10; // force to default on init
           this.users = res.users[0].results;

--- a/src/app/project/project-groups/project-contact-group-resolver.services.ts
+++ b/src/app/project/project-groups/project-contact-group-resolver.services.ts
@@ -15,7 +15,7 @@ export class ProjectContactsGroupResolver implements Resolve<Observable<object>>
     const projId = route.parent.paramMap.get('projId');
     const groupId = route.paramMap.get('groupId');
     const pageNum = route.params.pageNum ? route.params.pageNum : 1;
-    const pageSize = route.params.pageSize ? route.params.pageSize : 25;
+    const pageSize = route.params.pageSize ? route.params.pageSize : 10;
     const sortBy = route.params.sortBy ? route.params.sortBy : '+displayName';
 
     return this.projectService.getGroupMembers(projId, groupId, pageNum, pageSize, sortBy);

--- a/src/app/project/project-groups/project-groups-resolver.services.ts
+++ b/src/app/project/project-groups/project-groups-resolver.services.ts
@@ -14,7 +14,7 @@ export class ProjectContactsResolver implements Resolve<Observable<object>> {
   resolve(route: ActivatedRouteSnapshot): Observable<object> {
     const projectId = route.parent.paramMap.get('projId');
     const pageNum = route.params.pageNum ? route.params.pageNum : 1;
-    const pageSize = route.params.pageSize ? route.params.pageSize : 25;
+    const pageSize = route.params.pageSize ? route.params.pageSize : 10;
     const sortBy = route.params.sortBy ? route.params.sortBy : '+displayName';
 
     // force-reload so we always have latest data

--- a/src/app/shared/components/table-template/table-template.component.html
+++ b/src/app/shared/components/table-template/table-template.component.html
@@ -25,7 +25,7 @@
 </table>
 <div class="page-controls text-center pt-3 pb-3">
     <nz-pagination
-        *ngIf="data.paginationData.totalListItems > 10"
+        *ngIf="data.paginationData.totalListItems >= 10"
         [nzPageIndex]="activePage"
         (nzPageIndexChange)="updatePageNumber($event)"
         (nzPageSizeChange)="updatePageSize($event)"

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -25,6 +25,6 @@
     <a [ngClass]="{'active': mainRouteId.includes('contacts') || mainRouteId === 'c'}" id="contacts" [routerLink]="['/contacts']"><i class="material-icons mr-3 ">contacts</i>Contacts</a>
     <a [ngClass]="{'active': mainRouteId.includes('orgs') || mainRouteId === 'o'}" id="orgs" [routerLink]="['/orgs']"><i class="material-icons mr-3 ">business</i>Organizations</a>
     <a [ngClass]="{'active': mainRouteId === 'administration'}" id="settings" [routerLink]="['/administration']"><i class="material-icons mr-3 ">settings</i>Settings</a>
-    <a  href="https://intranet.gov.bc.ca/eao/eguide-2002-ea-act" id="eguide" target="_blank"><i class="material-icons mr-3 ">chrome_reader_mode</i>E-Guide</a>
+    <a  href="https://intranet.gov.bc.ca/eao/e-guide" id="eguide" target="_blank"><i class="material-icons mr-3 ">chrome_reader_mode</i>E-Guide</a>
   </section>
 </div>


### PR DESCRIPTION
Fix to use total counts from group members API call. Some adjustments to default page size handling

Part of a fix for admin group member sorting/paging. See ticket [EE-959](https://bcmines.atlassian.net/browse/EE-959)

Note, you will also need the API update from [PR 451](https://github.com/bcgov/eagle-api/pull/451)