### PR TITLE
Remove add documents from pcp ee 970

### DIFF
--- a/src/app/comment-periods/add-edit-comment-period/add-edit-comment-period.component.html
+++ b/src/app/comment-periods/add-edit-comment-period/add-edit-comment-period.component.html
@@ -123,7 +123,7 @@
             </div>
         </div>
 
-        <div class="form-row">
+        <div class="form-row" *ngIf="this.currentProject.type === 'currentProject'">
             <div class="form-group col-md-12">
                 <label for="documentsSel">Related Documents</label>
                 <ul class="doc-list mb-3" *ngIf="storageService.state.selectedDocumentsForCP">


### PR DESCRIPTION
Adding an ngIf to prevent the display of the related documents section and button if we're adding a PCP to a project notification.

See ticket [EE-970](https://bcmines.atlassian.net/browse/EE-970)