### PR TITLE
Notification decision date defaults fix

### DIFF
--- a/src/app/project-notifications/add-edit-project-notification/add-edit-project-notification.component.ts
+++ b/src/app/project-notifications/add-edit-project-notification/add-edit-project-notification.component.ts
@@ -82,7 +82,7 @@ export class AddEditProjectNotificationComponent implements OnInit, OnDestroy {
             'region': '',
             'location': '',
             'decision': '',
-            'decisionDate': '',
+            'decisionDate': undefined,
             'description': '',
             'centroid': ['', ''],
             'trigger': '',
@@ -94,7 +94,8 @@ export class AddEditProjectNotificationComponent implements OnInit, OnDestroy {
           }
 
           let editData = { ...this.projectNotification  };
-          editData.decisionDate = this.utils.convertJSDateToNGBDate(new Date(this.projectNotification.decisionDate)) as any;
+          // new Date(null) will create a date of 31/12/1969, so if decisionDate is null, don't create a date object here.
+          editData.decisionDate = this.projectNotification.decisionDate !== null ? this.utils.convertJSDateToNGBDate(new Date(this.projectNotification.decisionDate)) : undefined as any;
           this.buildForm(editData);
           this.subTypeSelected = this.PROJECT_SUBTYPES[this.myForm.controls.type.value];
         }
@@ -123,11 +124,17 @@ export class AddEditProjectNotificationComponent implements OnInit, OnDestroy {
       trigger: this.myForm.value.trigger,
       region: this.myForm.value.region,
       location: this.myForm.value.location,
-      decisionDate: this.myForm.value.decisionDate ? new Date(moment(this.utils.convertFormGroupNGBDateToJSDate(this.myForm.value.decisionDate))).toISOString() : null,
+      decisionDate: this.myForm.value.decisionDate !== null && this.myForm.value.decision !== 'In Progress' ? new Date(moment(this.utils.convertFormGroupNGBDateToJSDate(this.myForm.value.decisionDate))) : null,
       decision: this.myForm.value.decision,
       description: this.myForm.value.description,
       centroid: [this.myForm.value.latitude, this.myForm.value.longitude]
     });
+
+    // Failsafe: if the decisionDate is set to new Date(null) it'll create a date in 1969.
+    // we can assume a date of 31/12/1969@8:00 should actually be null
+    if (notificationProject.decisionDate && notificationProject.decisionDate.toISOString() === '1969-12-31T08:00:00.000Z') {
+      notificationProject.decisionDate === null;
+    }
 
     if (this.isAdd) {
       this.notificationProjectService.add(notificationProject, publish)


### PR DESCRIPTION
Decision Dates could default to 31/12/1969 on update. Fix to remove areas where new Date(null) was creating default dates, added a check to null it out on In Progress decisions, and a failsafe to check if a date equals "1969-12-31T08:00:00.000Z" and reverting it to null.

See ticket [EE-969](https://bcmines.atlassian.net/browse/EE-969)