### PR TITLE
Fix to automated PR scripts

### DIFF
--- a/.github/workflows/pull_request_hotfix.yml
+++ b/.github/workflows/pull_request_hotfix.yml
@@ -1,10 +1,9 @@
 name: Create develop/master branch PRa
 
 on:
-  pull_request:
+  push:
     branches:
     - hotfix
-    types: [closed]
 
 jobs:
   pull-request-develop:

--- a/.github/workflows/pull_request_master.yml
+++ b/.github/workflows/pull_request_master.yml
@@ -3,10 +3,9 @@
 name: Create master branch PR
 
 on:
-  pull_request:
+  push:
     branches:
     - test
-    types: [closed]
 
 jobs:
   pull-request:
@@ -20,6 +19,6 @@ jobs:
         destination_branch: "master"
         pr_title: "Pulling ${{ github.ref }} into MASTER"
         pr_body: ":crown: *An automated PR*  This PR will pull all recent merges from TEST into MASTER - NOTE: This will deploy to production! Do not merge unless you're sure."
-        pr_label: "auto-pr from test to master" 
+        pr_label: "auto-pr from test to master"
         pr_draft: true
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -3,10 +3,9 @@
 name: Create test branch PR
 
 on:
-  pull_request:
+  push:
     branches:
     - develop
-    types: [closed]
 
 jobs:
   pull-request:


### PR DESCRIPTION
Changed scripts from pull-request closed trigger to on-push-branches to prevent issues with closed/deleted PR's that wont be merged