### PR TITLE
Null notificationName value if not PN PCP

### DIFF
--- a/src/app/activity/add-edit-activity/add-edit-activity.component.ts
+++ b/src/app/activity/add-edit-activity/add-edit-activity.component.ts
@@ -111,7 +111,7 @@ export class AddEditActivityComponent implements OnInit, OnDestroy {
         project: this.myForm.get('project').value,
         type: this.myForm.get('type').value,
         pcp: this.myForm.get('pcp').value,
-        notificationName: this.myForm.controls.notificationName.value,
+        notificationName: this.myForm.get('type').value === 'Project Notification Public Comment Period' ? this.myForm.controls.notificationName.value : null,
 
         contentUrl: this.myForm.controls.contentUrl.value,
         documentUrl: this.myForm.controls.documentUrl.value,
@@ -131,12 +131,13 @@ export class AddEditActivityComponent implements OnInit, OnDestroy {
         project: this.myForm.get('project').value,
         type: this.myForm.get('type').value,
         pcp: this.myForm.get('pcp').value,
-        notificationName: this.myForm.controls.notificationName.value,
+        notificationName: this.myForm.get('type').value === 'Project Notification Public Comment Period' ? this.myForm.controls.notificationName.value : null,
         contentUrl: this.myForm.controls.contentUrl.value,
         documentUrl: this.myForm.controls.documentUrl.value,
         pinned: false,
         active: this.myForm.controls.active.value === 'yes' ? true : false
       });
+
       this.recentActivityService.add(activity)
         .subscribe(() => {
           this.snackBar.open('Activity Added!', 'Close', { duration: this.snackBarTimeout});


### PR DESCRIPTION
If a user saves an Activity Post and the type is Public Comment Period, null out any existing value in notificationName (it is not a PN PCP).

See ticket [EE-1059](https://bcmines.atlassian.net/browse/EE-1059)