### PR TITLE
Removed the extra comment period descriptive preview

### DIFF
--- a/src/app/comment-periods/add-edit-comment-period/add-edit-comment-period.component.html
+++ b/src/app/comment-periods/add-edit-comment-period/add-edit-comment-period.component.html
@@ -116,8 +116,6 @@
                 </h6>
                 <p class="text-secondary">
                     Comment Period on the {{infoForCommentPreview}} for {{currentProject.data.name}} Project.
-                    <br>
-                    {{descriptionPreview}}
                 </p>
                 <div class="renderedTextPreview" [innerHTML]="descriptionPreview  | safeHtml"></div>
             </div>


### PR DESCRIPTION
There was an extra tag displaying the description. It's been removed.

See ticket [EE-1070](https://bcmines.atlassian.net/browse/EE-1070)