### PR TITLE
EE-1110: Fix comment count display

### DIFF
--- a/src/app/comment-period/review-comments-tab/review-comments-tab.component.html
+++ b/src/app/comment-period/review-comments-tab/review-comments-tab.component.html
@@ -31,8 +31,8 @@
       </div>
     </div>
   </div>
-  <div class="result-num">
-    Displaying <strong>{{tableParams.pageSize}} of {{tableParams.totalListItems}}</strong> Comments
+  <div class="result-num" *ngIf="tableParams.totalListItems > 0 && !loading">
+    Displaying <strong>{{tableParams.totalListItems > tableParams.pageSize ? (tableParams.pageSize * tableParams.currentPage - (tableParams.pageSize - 1)) + '-' + (tableParams.pageSize * tableParams.currentPage) + ' of ' : ''}}{{tableParams.totalListItems}}</strong> Comments
   </div>
 </section>
 


### PR DESCRIPTION
Update to the comment period count label. Adjusted to display "Displaying # comments" if there is only one page of results, and if there are multiple pages, to say eg. "Displaying 1-10 of 20 comments."

Note, it appears this is pretty much the only page that actually shows a record count above the list, so for consistency we might want to consider adding this to the other tables, or just removing it from this one?

See ticket [EE-1110](https://bcmines.atlassian.net/browse/EE-1110)