### PR TITLE
Maintains Line Breaks for Comment Display

### DIFF
--- a/src/app/comment-period/review-comment/review-comment.component.html
+++ b/src/app/comment-period/review-comment/review-comment.component.html
@@ -85,7 +85,7 @@
           [ngClass]="{'bg-success': comment.submittedCAC, 'bg-danger': !comment.submittedCAC}">{{comment.submittedCAC ? 'Yes' : 'No'}}</div>
         </div>
         <div class="row">
-          <div class="col-md-12">
+          <div class="col-md-12 comment">
             {{comment.comment}}
           </div>
         </div>

--- a/src/app/comment-period/review-comment/review-comment.component.scss
+++ b/src/app/comment-period/review-comment/review-comment.component.scss
@@ -38,6 +38,10 @@ input[type="text"] {
   }
 }
 
+.comment {
+  white-space: pre-wrap;
+}
+
 @media screen and (max-width: 768px) {
   .btn-group-toggle {
     display: block;


### PR DESCRIPTION
No ticket.  When public comments were reviewed it would not maintain any line breaks or whitespace that was entered.  Now it will maintain the formatting when displaying the comment.