### PR TITLE
Sets default organization soft order to name

### DIFF
--- a/src/app/organizations/organizations-resolver.service.ts
+++ b/src/app/organizations/organizations-resolver.service.ts
@@ -18,9 +18,12 @@ export class OrganizationsResolver implements Resolve<object> {
     let tableParams;
     if (this.storageService.state.orgTableParams) {
       tableParams = this.storageService.state.orgTableParams;
-      this.tableTemplateUtils.updateUrl(tableParams.sortBy, tableParams.currentPage, tableParams.pageSize, tableParams.filter, tableParams.keywords);
     } else {
       tableParams = this.tableTemplateUtils.getParamsFromUrl(route.params, null, null, ['companyType']);
+      if (tableParams.sortBy === '') {
+        tableParams.sortBy = '+name';
+      }
+      this.tableTemplateUtils.updateUrl(tableParams.sortBy, tableParams.currentPage, tableParams.pageSize, tableParams.filter, tableParams.keywords);
     }
 
     let filterObj = {};

--- a/src/app/organizations/organizations.component.ts
+++ b/src/app/organizations/organizations.component.ts
@@ -80,11 +80,15 @@ export class OrganizationsComponent implements OnInit, OnDestroy {
       .subscribe(params => {
         if (this.storageService.state.orgTableParams) {
           this.tableParams = this.storageService.state.orgTableParams;
-          this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, this.tableParams.filter, this.tableParams.keywords);
           this.storageService.state.orgTableParams = null;
         } else {
           this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, null, null, ['companyType']);
+          if (this.tableParams.sortBy === '') {
+            this.tableParams.sortBy = '+name';
+          }
         }
+        this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, this.tableParams.filter, this.tableParams.keywords);
+
         if (this.tableParams.filter && this.tableParams.filter.companyType) {
           this.setFilterButtons();
         }


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/EE-1167

This sets the default sort order to name for the organization list page.  It has to be set in two places due to how the 'getParamsFromUrl' function currently behaves. Changing that function will require a refactor across the whole application so I am going to make a separate ticket for that work so this bug fix can be pushed through.