### PR TITLE
NOBUG: Use artifactory for pulling nginx

### DIFF
--- a/openshift/templates/nginx-runtime/Dockerfile
+++ b/openshift/templates/nginx-runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:mainline
+FROM docker-remote.artifacts.developer.gov.bc.ca/nginx:mainline
 
 ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
 

--- a/openshift/templates/nginx-runtime/nginx-runtime.json
+++ b/openshift/templates/nginx-runtime/nginx-runtime.json
@@ -34,6 +34,11 @@
           "contextDir": "openshift/templates/nginx-runtime/"
         },
         "strategy": {
+          "dockerStrategy": {
+            "pullSecret": {
+              "name": "artifactory-pull-secret"
+            }
+          },
           "type": "Docker"
         },
         "output": {


### PR DESCRIPTION
Use Artifactory for pulling docker image.  This has been tested on both OCP3 and OCP4.