### PR TITLE
EE-1236 project notification documents list not refreshing after document delete

### DIFF
--- a/src/app/project-notification/documents/project-notification-documents.component.ts
+++ b/src/app/project-notification/documents/project-notification-documents.component.ts
@@ -88,7 +88,9 @@ export class ProjectNotificationDocumentsComponent implements OnInit, OnDestroy 
     private snackBar: MatSnackBar,
     private storageService: StorageService,
     private utils: Utils
-  ) { }
+  ) {
+    this.router.routeReuseStrategy.shouldReuseRoute = () => false;
+  }
 
   ngOnInit() {
     this.route.parent.data
@@ -356,7 +358,7 @@ export class ProjectNotificationDocumentsComponent implements OnInit, OnDestroy 
   public onSubmit() {
     this.loading = true;
 
-    const params = { };
+    const params = {};
     params['ms'] = new Date().getMilliseconds();
     params['notificationProjectId'] = this.currentProject._id;
 

--- a/src/app/project-notification/documents/project-notification-documents.component.ts
+++ b/src/app/project-notification/documents/project-notification-documents.component.ts
@@ -362,6 +362,9 @@ export class ProjectNotificationDocumentsComponent implements OnInit, OnDestroy 
     params['ms'] = new Date().getMilliseconds();
     params['notificationProjectId'] = this.currentProject._id;
 
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+
     this.router.navigate([
       'pn',
       this.currentProject._id,


### PR DESCRIPTION
Angular by default does not call `ngOnInit` if navigating to an unchanged URL. This change ensures that the default is changed so that the page reloads on navigating to the same URL.