### PR TITLE
Revert "Bump moment-timezone from 0.5.14 to 0.5.35"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "leaflet": "^1.3.1",
     "lodash": "~4.17.15",
     "moment": "2.24.0",
-    "moment-timezone": "0.5.35",
+    "moment-timezone": "0.5.14",
     "mygovbc-bootstrap-theme": "~0.4.1",
     "ng-zorro-antd": "10.2.2",
     "ngx-cookie-service": "~10",


### PR DESCRIPTION
Reverts bcgov/eagle-admin#756