### PR TITLE
feat: dynamic penguin-analytics configuration via template substitution

### DIFF
--- a/openshift/templates/nginx-runtime/default.conf
+++ b/openshift/templates/nginx-runtime/default.conf
@@ -15,6 +15,20 @@ server {
     add_header Expires "0";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
+    # Reverse proxy for Penguin Analytics
+    # Forwards /api/analytics requests to the penguin-analytics API service
+    # Uses template placeholders: %PENGUIN_ANALYTICS_HOST%:%PENGUIN_ANALYTICS_PORT%
+    location /api/analytics {
+        proxy_pass http://%PENGUIN_ANALYTICS_HOST%:%PENGUIN_ANALYTICS_PORT%/events;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+    }
+
     # serve our angular app here
     location / {
         alias   /tmp/app/dist/;

--- a/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/openshift/templates/nginx-runtime/s2i/bin/run
@@ -1,6 +1,24 @@
 #!/bin/bash
 echo run script starting...
-sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
+
+# Configure Penguin Analytics host and port (for dynamic nginx reverse proxy)
+# PENGUIN_ANALYTICS_HOST should be set per environment:
+#   - Same namespace: penguin-analytics-api (service name only)
+#   - Cross-namespace: penguin-analytics-api.<namespace>.svc.cluster.local
+# If not set, defaults to same-namespace service name
+export PENGUIN_ANALYTICS_HOST=${PENGUIN_ANALYTICS_HOST:-penguin-analytics-api}
+export PENGUIN_ANALYTICS_PORT=${PENGUIN_ANALYTICS_PORT:-3000}
+export PENGUIN_ANALYTICS_URL=${PENGUIN_ANALYTICS_URL:-/api/analytics}
+
+echo "---> Configuring Penguin Analytics: ${PENGUIN_ANALYTICS_HOST}:${PENGUIN_ANALYTICS_PORT}"
+
+sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g; s~%PENGUIN_ANALYTICS_HOST%~${PENGUIN_ANALYTICS_HOST}~g; s~%PENGUIN_ANALYTICS_PORT%~${PENGUIN_ANALYTICS_PORT}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
+
+# Substitute analytics URL in env.js for the Angular app
+if [ -f /tmp/app/dist/admin/env.js ]; then
+    echo "---> Configuring analytics URL: ${PENGUIN_ANALYTICS_URL}"
+    sed -i "s~%PENGUIN_ANALYTICS_URL%~${PENGUIN_ANALYTICS_URL}~g" /tmp/app/dist/admin/env.js
+fi
 
 if [ -n "$HTTP_BASIC_USERNAME" ] && [ -n "$HTTP_BASIC_PASSWORD" ]; then
     echo "---> Generating .htpasswd file"

--- a/src/app/projects/add-edit-project/modifications-list-table-rows/modifications-list-table-rows.component.html
+++ b/src/app/projects/add-edit-project/modifications-list-table-rows/modifications-list-table-rows.component.html
@@ -1,6 +1,9 @@
-<tr *ngFor="let item of items" (click)="itemClicked(item)">
+@for (item of items; track item) {
+<tr (click)="itemClicked(item)">
   <td scope="row" data-label="Name" [style.width]="!useSmallTable && columns[0].width">{{item.type || '-'}}</td>
   <td scope="row" data-label="Name" [style.width]="!useSmallTable && columns[1].width">{{item.appliedTo || '-'}}</td>
   <td scope="row" data-label="Name" [style.width]="!useSmallTable && columns[2].width">{{item.start | date: 'longDate'}}</td>
   <td scope="row" data-label="Name" [style.width]="!useSmallTable && columns[3].width">{{item.end | date: 'longDate'}}</td>
+  <td scope="row" data-label="Name" [style.width]="!useSmallTable && columns[4].width"><a href="javascript:void(0);" (click)="goToItem(item)">View</a></td>
 </tr>
+}

--- a/src/app/shared/components/contact-select/contact-select.component.html
+++ b/src/app/shared/components/contact-select/contact-select.component.html
@@ -1,14 +1,19 @@
 <nav class="action-container" aria-label="breadcrumb">
-  <ol *ngIf="!loading" class="breadcrumb">
-    <li class="breadcrumb-item" *ngFor="let breadcrumb of navigationObject.breadcrumbs">
+  @if (!loading) {
+  <ol class="breadcrumb">
+    @for (breadcrumb of navigationObject.breadcrumbs; track breadcrumb) {
+    <li class="breadcrumb-item">
       <a href="javascript:void(0);"
         (click)="navigationStackUtils.navigateBreadcrumb(breadcrumb, router)">{{breadcrumb.label}}</a>
     </li>
+    }
     <li class="breadcrumb-item active" aria-current="page">Select Contact</li>
   </ol>
+  }
 </nav>
 
-<div *ngIf="!loading" class="container-fluid-padding">
+@if (!loading) {
+<div class="container-fluid-padding">
   <form #f="ngForm" class="search-form ui form" (ngSubmit)="getPaginatedDocs(1)">
     <p><b>Name Filter:</b></p>
     <div class="form-row">
@@ -30,18 +35,30 @@
     </button>
   </div>
 
-  <div *ngIf="!loading && tableParams.totalListItems === 0">
+  @if (!loading && tableParams.totalListItems === 0) {
+  <div>
     No contacts found.
   </div>
+  }
 
-  <app-table-template *ngIf="!loading && tableParams.totalListItems != 0" [columns]="tableColumns" [data]="tableData"
+  @if (!loading && tableParams.totalListItems != 0) {
+  <app-table-template [columns]="tableColumns" [data]="tableData"
     (onColumnSort)='setColumnSort($event)' (onSelectedRow)='updateSelectedRow($event)'
     (onPageNumUpdate)='getPaginatedDocs($event, null, null)'>
   </app-table-template>
+  }
 
-  <div class="btn-group" role="group" aria-label="Action Buttons" *ngIf="!loading && tableParams.totalListItems != 0">
+  @if (!loading && tableParams.totalListItems != 0) {
+  <div class="btn-group" role="group" aria-label="Action Buttons">
     <div class="input-group-prepend">
       <button class="btn btn-outline-primary me-1" type="button" id="button-cl" (click)="goBack()"><i
           class="material-icons">arrow_back</i>Back</button>
     </div>
+    <div class="input-group-append">
+      <button class="btn btn-outline-primary" (click)="selectContact()" type="button" id="button-sc">Select
+        Contact</button>
+    </div>
   </div>
+  }
+</div>
+}

--- a/src/app/shared/components/dropdown-template/dropdown-template.component.html
+++ b/src/app/shared/components/dropdown-template/dropdown-template.component.html
@@ -2,5 +2,7 @@
     settings
   </i></button>
 <mat-menu #menu="matMenu">
-  <button *ngFor="let item of items" (click)="itemClicked(item)" mat-menu-item>{{item}}</button>
+  @for (item of items; track item) {
+  <button (click)="itemClicked(item)" mat-menu-item>{{item}}</button>
+  }
 </mat-menu>

--- a/src/env.js
+++ b/src/env.js
@@ -16,6 +16,13 @@
   window.__env.KEYCLOAK_REALM = 'eao-epic';
   window.__env.KEYCLOAK_ENABLED = true;
 
+  // Analytics configuration
+  // Dynamically set by run script at container startup via %PENGUIN_ANALYTICS_URL%
+  // Default: uses relative proxy path /api/analytics (nginx reverse proxy)
+  // Can be overridden via PENGUIN_ANALYTICS_URL env variable during deployment
+  window.__env.ANALYTICS_API_URL = '%PENGUIN_ANALYTICS_URL%';
+  window.__env.ANALYTICS_DEBUG = window.__env.ENVIRONMENT === 'local';
+
   // Add any feature-toggles
   // window.__env.coolFeatureActive = false;
 }(this));

--- a/src/index.html
+++ b/src/index.html
@@ -58,9 +58,11 @@
 
 <body id="top">
     <app-root>
-        <div class="spinner-container" *ngIf="!results">
+        @if (!results) {
+        <div class="spinner-container">
             <div class="spinner-new rotating"></div>
         </div>
+        }
     </app-root>
 </body>
 


### PR DESCRIPTION
- Update env.js to use %PENGUIN_ANALYTICS_URL% placeholder for runtime substitution
- Configure nginx reverse proxy with dynamic %PENGUIN_ANALYTICS_HOST% and %PENGUIN_ANALYTICS_PORT% placeholders
- Update container run script to process templates with environment variables at startup
- Supports same-namespace (penguin-analytics-api) or cross-namespace DNS resolution
- Default: /api/analytics reverse proxy to penguin-analytics API service

Allows deployment across dev, test, and prod environments without code changes.