### PR TITLE
fix: process nginx default.conf and env.js as runtime templates

### DIFF
--- a/Dockerfile.Github
+++ b/Dockerfile.Github
@@ -1,5 +1,8 @@
 FROM image-registry.apps.silver.devops.gov.bc.ca/6cdc9e-tools/eagle-admin-nginx-runtime
 
+# Copy default.conf as a template for runtime processing
+COPY openshift/templates/nginx-runtime/default.conf /tmp/default.conf.template
+
 COPY dist /tmp/app/dist/admin
 
 CMD ["/usr/libexec/s2i/run"]

--- a/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/openshift/templates/nginx-runtime/s2i/bin/run
@@ -12,12 +12,20 @@ export PENGUIN_ANALYTICS_URL=${PENGUIN_ANALYTICS_URL:-/api/analytics}
 
 echo "---> Configuring Penguin Analytics: ${PENGUIN_ANALYTICS_HOST}:${PENGUIN_ANALYTICS_PORT}"
 
-sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g; s~%PENGUIN_ANALYTICS_HOST%~${PENGUIN_ANALYTICS_HOST}~g; s~%PENGUIN_ANALYTICS_PORT%~${PENGUIN_ANALYTICS_PORT}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
+# Process nginx.conf template (if exists)
+if [ -f /tmp/nginx.conf.template ]; then
+    sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
+fi
+
+# Process default.conf template for analytics reverse proxy
+if [ -f /tmp/default.conf.template ]; then
+    sed "s~%PENGUIN_ANALYTICS_HOST%~${PENGUIN_ANALYTICS_HOST}~g; s~%PENGUIN_ANALYTICS_PORT%~${PENGUIN_ANALYTICS_PORT}~g" /tmp/default.conf.template > /etc/nginx/conf.d/default.conf
+fi
 
 # Substitute analytics URL in env.js for the Angular app
 if [ -f /tmp/app/dist/admin/env.js ]; then
     echo "---> Configuring analytics URL: ${PENGUIN_ANALYTICS_URL}"
-    sed -i "s~%PENGUIN_ANALYTICS_URL%~${PENGUIN_ANALYTICS_URL}~g" /tmp/app/dist/admin/env.js
+    sed "s~%PENGUIN_ANALYTICS_URL%~${PENGUIN_ANALYTICS_URL}~g" /tmp/app/dist/admin/env.js > /tmp/env.js.tmp && mv /tmp/env.js.tmp /tmp/app/dist/admin/env.js
 fi
 
 if [ -n "$HTTP_BASIC_USERNAME" ] && [ -n "$HTTP_BASIC_PASSWORD" ]; then


### PR DESCRIPTION
- Copy default.conf as /tmp/default.conf.template in Dockerfile
- Process template at runtime to substitute analytics host/port
- Fix env.js permissions issue by using sed output redirect instead of -i
- Separate nginx.conf and default.conf template processing