### PR TITLE
PUBLIC-108: Activity Post Dropdowns Failing to Load on Project Notification News and Public Comment Period Types

### DIFF
--- a/src/app/activity/add-edit-activity/add-edit-activity.component.html
+++ b/src/app/activity/add-edit-activity/add-edit-activity.component.html
@@ -66,11 +66,7 @@
       Please select a Project Notification.
     </div>
     }
-    @if (typeIsPCP && projectIsSelected && periods.length === 0) {
-    <div class="alert alert-warning" role="alert">
-      No public comment periods exist for selected project.
-    </div>
-    }
+
     <div class="flex-container">
       <div class="label-pair med">
         @if (!typeIsPCP && !typeIsProjectNotificationNews) {
@@ -123,6 +119,9 @@
             {{period.dateCompleted | date}}</option>
           }
         </select>
+        @if (typeIsPCP && projectIsSelected && periods.length === 0) {
+        <small class="form-text text-danger fw-semibold">⚠ No public comment periods found for this project. Please create one before adding this activity.</small>
+        }
       </div>
     </div>
     <div class="flex-container">

--- a/src/app/activity/add-edit-activity/add-edit-activity.component.ts
+++ b/src/app/activity/add-edit-activity/add-edit-activity.component.ts
@@ -232,7 +232,8 @@ export class AddEditActivityComponent implements OnInit {
       this.typeIsPCP = true;
       this.typeIsNotification = false;
       this.typeIsProjectNotificationNews = false;
-      this.myForm.get('pcp')!.enable();
+      // pcp stays disabled until periods load — prevents black bar on empty select
+      this.myForm.controls['pcp'].reset({ value: '', disabled: true });
       this.myForm.get('project')!.enable();
       this.myForm.get('project')!.setValidators(Validators.required);
       this.myForm.get('pcp')!.setValidators(Validators.required);
@@ -307,6 +308,12 @@ export class AddEditActivityComponent implements OnInit {
           const currentPcp = this.myForm.controls['pcp'].value;
           if (!this.periods.some((p: any) => p._id === currentPcp)) {
             this.myForm.controls['pcp'].setValue('');
+          }
+          // Enable pcp select only when periods exist — prevents black bar on empty select
+          if (this.typeIsPCP && this.periods.length > 0) {
+            this.myForm.get('pcp')!.enable();
+          } else {
+            this.myForm.controls['pcp'].reset({ value: '', disabled: true });
           }
           this._cdr.markForCheck();
         }

--- a/src/app/services/notification-project.service.ts
+++ b/src/app/services/notification-project.service.ts
@@ -19,7 +19,7 @@ export class NotificationProjectService {
   private projectNotificationList: ProjectNotification[] = [];
 
   getAll(pageNum = 1, pageSize = 20, sortBy: string = null): Observable<object> {
-    const fields = ['name', 'epicProjectID', 'location', 'decisionDate'];
+    const fields = ['name', 'location', 'decisionDate'];
     let qs = `projectNotification?`;
     if (pageNum !== null) { qs += `pageNum=${pageNum - 1}&`; }
     if (pageSize !== null) { qs += `pageSize=${pageSize}&`; }


### PR DESCRIPTION
## Problem

Two broken dropdowns on the Add Activity Post form:

**Project Notification News** — selecting this type then opening the Project Notification dropdown showed a "Failed to load project notifications" error. Root cause was in `eagle-api` (separate commit on `develop`: `924223b`) — the `projectNotification` controller ignored all pagination/sort params causing unbounded queries, and triggered unnecessary `$lookup` stages on the entire `epic` collection via `populateProponent: true` (proponent is a plain string on this model, not an ObjectId ref).

**Public Comment Period** — the PCP dropdown showed a black bar. Root cause: the PCP `<select>` was being enabled before periods loaded, resulting in an empty enabled select. Also, switching between projects could leave the select enabled when the new project had no PCPs.

## Changes

- Remove `epicProjectID` from `NotificationProjectService` fields request — not in the ProjectNotification schema or swagger enum
- Keep PCP select disabled until `loadPcpsForProject()` resolves with results; explicitly re-disable if the resolved project has no comment periods (fixes stale enabled state when switching projects)
- Replace detached alert box with inline `form-text` anchored directly under the PCP select for clearer field association
- Show a red bold warning under the PCP select when selected project has no comment periods, instead of a floating yellow alert box

## Related

- `eagle-api` fix committed directly to `develop`: `924223b` — fixes the `/api/projectNotification` 504 Gateway Timeout